### PR TITLE
Feat/native promises with rejection and mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rn-fitness-tracker
 
+[![npm version](https://badgen.net/npm/v/@kilohealth/rn-fitness-tracker)](https://www.npmjs.com/package/@kilohealth/rn-fitness-tracker)
+
 React Native library for step tracking based on Google Fit (Android) and CoreMotion (iOS) native API's.
 
 ## Installation
@@ -19,7 +21,7 @@ React Native library for step tracking based on Google Fit (Android) and CoreMot
 
 **or**
 
-Navigate to info.plist file in XCode ➜ Add new property list key - `NSMotionUsageDescription`. 
+Navigate to info.plist file in XCode ➜ Add new property list key - `NSMotionUsageDescription`.
 This will add new line in the containing `Privacy - Motion Usage Description`.
 
 <details><summary><b>React-Native < 0.60 - Manual linking for projects with older react-native version</b></summary>
@@ -34,7 +36,6 @@ This will add new line in the containing `Privacy - Motion Usage Description`.
 </p>
 </details>
 
-
 ## Android
 
 #### React-Native > 0.61
@@ -48,8 +49,8 @@ This will add new line in the containing `Privacy - Motion Usage Description`.
 
 2. [Create an OAuth screen](https://console.developers.google.com/apis/credentials/consent) for your project.
 
-3. Select `User Type: External` and fill out the form. Add `../auth/fitness.activity.read` to 
-**Scopes for Google APIs**.
+3. Select `User Type: External` and fill out the form. Add `../auth/fitness.activity.read` to
+   **Scopes for Google APIs**.
 
 4. Fill out next popup forms with a brief explanation why you're using the activity tracker (no need to write much).
 
@@ -57,9 +58,9 @@ This will add new line in the containing `Privacy - Motion Usage Description`.
 
 6. Select your app's project, `Continue`, and `Go to Credentials`.
 
-7. Where will you be calling the API from? Select `Android`. 
+7. Where will you be calling the API from? Select `Android`.
 
-8. What data will you be accessing? Select `User data` and click next. 
+8. What data will you be accessing? Select `User data` and click next.
 
 9. The **Signing-certificate fingerprint** generation command must be pointed to your app release / staging keystore file.
 
@@ -67,7 +68,6 @@ This will add new line in the containing `Privacy - Motion Usage Description`.
 
 </p>
 </details>
-
 
 2. React Native autolinking should handle the rest.
 

--- a/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
+++ b/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
@@ -77,6 +77,7 @@ public class GoogleFitManager implements ActivityEventListener {
                 accessGoogleFit();
             }
         } catch (Exception e) {
+            authorisationPromise.reject(e);
             e.printStackTrace();
         }
     }
@@ -93,6 +94,7 @@ public class GoogleFitManager implements ActivityEventListener {
                 authorisationPromise.resolve(true);
             }
         } catch (Exception e) {
+            authorisationPromise.reject(e);
             e.printStackTrace();
         }
     }
@@ -100,10 +102,10 @@ public class GoogleFitManager implements ActivityEventListener {
 
     private void requestFitnessPermissions(GoogleSignInAccount googleSignInAccount) {
         GoogleSignIn.requestPermissions(
-            activity,
-            GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,
-            googleSignInAccount,
-            fitnessOptions
+                activity,
+                GOOGLE_FIT_PERMISSIONS_REQUEST_CODE,
+                googleSignInAccount,
+                fitnessOptions
         );
     }
 
@@ -113,67 +115,35 @@ public class GoogleFitManager implements ActivityEventListener {
             this.recordingService.subscribe();
             this.historyClient = new HistoryClient(activity);
             authorisationPromise.resolve(true);
-        }catch (Exception e) {
+        } catch (Exception e) {
+            authorisationPromise.reject(e);
             e.printStackTrace();
         }
     }
 
     public void getStepsToday(final Promise promise) {
-        this.historyClient.getStepsToday(new HistoryCallback() {
-            @Override
-            public void sendData(Object steps) {
-                promise.resolve(steps);
-            }
-        });
+        this.historyClient.getStepsToday(promise);
     }
 
     public void getStepsWeekTotal(final Promise promise) {
-        this.historyClient.getWeekData(new HistoryCallback() {
-            @Override
-            public void sendData(Object steps) {
-                promise.resolve(steps);
-            }
-        }, 0);
+        this.historyClient.getWeekData(promise, 0);
     }
 
     public void getStepsDaily(final Promise promise) {
-        this.historyClient.getStepsDaily(new Date(), Arguments.createMap(), 0,  new HistoryCallback() {
-            @Override
-            public void sendData(Object steps) {
-                WritableMap map = (WritableMap)steps;
-                promise.resolve(map);
-            }
-        });
+        this.historyClient.getStepsDaily(new Date(), Arguments.createMap(), 0, promise);
     }
 
     public void getDistanceToday(final Promise promise) {
-        this.historyClient.getDistanceToday(new HistoryCallback() {
-            @Override
-            public void sendData(Object distance) {
-                promise.resolve(distance);
-            }
-        });
+        this.historyClient.getDistanceToday(promise);
     }
 
     public void getDistanceWeekTotal(final Promise promise) {
-        this.historyClient.getWeekData(new HistoryCallback() {
-            @Override
-            public void sendData(Object steps) {
-                promise.resolve(steps);
-            }
-        }, 1);
+        this.historyClient.getWeekData(promise, 1);
     }
 
     public void getDistanceDaily(final Promise promise) {
-        this.historyClient.getDistanceDaily(new Date(), Arguments.createMap(), 0,  new HistoryCallback() {
-            @Override
-            public void sendData(Object steps) {
-                WritableMap map = (WritableMap)steps;
-                promise.resolve(map);
-            }
-        });
+        this.historyClient.getDistanceDaily(new Date(), Arguments.createMap(), 0, promise);
+
     }
-
-
 
 }

--- a/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
+++ b/android/src/main/java/com/fitnesstracker/GoogleFit/GoogleFitManager.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.auth.api.signin.GoogleSignIn;
@@ -25,7 +25,7 @@ public class GoogleFitManager implements ActivityEventListener {
     private RecordingService recordingService;
     private Activity activity;
     private ReactApplicationContext reactContext;
-    private Callback authorisationCallback;
+    private Promise authorisationPromise;
 
     FitnessOptions fitnessOptions = FitnessOptions.builder()
             .addDataType(DataType.TYPE_STEP_COUNT_DELTA, FitnessOptions.ACCESS_READ)
@@ -56,7 +56,7 @@ public class GoogleFitManager implements ActivityEventListener {
                 subscribeToActivityData();
                 accessGoogleFit();
             } else {
-                this.authorisationCallback.invoke(false);
+                this.authorisationPromise.resolve(false);
             }
         } else if (requestCode == SIGN_IN_REQUEST_CODE) {
             GoogleSignInAccount googleSignInAccount = GoogleSignIn.getLastSignedInAccount(activity);
@@ -64,10 +64,10 @@ public class GoogleFitManager implements ActivityEventListener {
         }
     }
 
-    public void authorize(Callback callback, Activity activity) {
+    public void authorize(Promise promise, Activity activity) {
         try {
             this.activity = activity;
-            this.authorisationCallback = callback;
+            this.authorisationPromise = promise;
 
             /* Check if app has google fit permissions */
             if (!GoogleSignIn.hasPermissions(GoogleSignIn.getLastSignedInAccount(this.reactContext), this.fitnessOptions)) {
@@ -81,16 +81,16 @@ public class GoogleFitManager implements ActivityEventListener {
         }
     }
 
-    public void isTrackingAvailable(Callback callback, Activity activity) {
+    public void isTrackingAvailable(Promise promise, Activity activity) {
         try {
             this.activity = activity;
-            this.authorisationCallback = callback;
+            this.authorisationPromise = promise;
 
             /* Check if app has google fit permissions */
             if (!GoogleSignIn.hasPermissions(GoogleSignIn.getLastSignedInAccount(this.reactContext), this.fitnessOptions)) {
-                authorisationCallback.invoke(false);
+                authorisationPromise.resolve(false);
             } else {
-                authorisationCallback.invoke(true);
+                authorisationPromise.resolve(true);
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -112,64 +112,64 @@ public class GoogleFitManager implements ActivityEventListener {
             this.recordingService = new RecordingService(activity);
             this.recordingService.subscribe();
             this.historyClient = new HistoryClient(activity);
-            authorisationCallback.invoke(true);
+            authorisationPromise.resolve(true);
         }catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    public void getStepsToday(final Callback callback) {
+    public void getStepsToday(final Promise promise) {
         this.historyClient.getStepsToday(new HistoryCallback() {
             @Override
             public void sendData(Object steps) {
-                callback.invoke((int)steps);
+                promise.resolve(steps);
             }
         });
     }
 
-    public void getStepsWeekTotal(final Callback callback) {
+    public void getStepsWeekTotal(final Promise promise) {
         this.historyClient.getWeekData(new HistoryCallback() {
             @Override
             public void sendData(Object steps) {
-                callback.invoke((int)steps);
+                promise.resolve(steps);
             }
         }, 0);
     }
 
-    public void getStepsDaily(final Callback callback) {
+    public void getStepsDaily(final Promise promise) {
         this.historyClient.getStepsDaily(new Date(), Arguments.createMap(), 0,  new HistoryCallback() {
             @Override
             public void sendData(Object steps) {
                 WritableMap map = (WritableMap)steps;
-                callback.invoke(map);
+                promise.resolve(map);
             }
         });
     }
 
-    public void getDistanceToday(final Callback callback) {
+    public void getDistanceToday(final Promise promise) {
         this.historyClient.getDistanceToday(new HistoryCallback() {
             @Override
             public void sendData(Object distance) {
-                callback.invoke((float)distance);
+                promise.resolve(distance);
             }
         });
     }
 
-    public void getDistanceWeekTotal(final Callback callback) {
+    public void getDistanceWeekTotal(final Promise promise) {
         this.historyClient.getWeekData(new HistoryCallback() {
             @Override
             public void sendData(Object steps) {
-                callback.invoke((float)steps);
+                promise.resolve(steps);
             }
         }, 1);
     }
 
-    public void getDistanceDaily(final Callback callback) {
+    public void getDistanceDaily(final Promise promise) {
         this.historyClient.getDistanceDaily(new Date(), Arguments.createMap(), 0,  new HistoryCallback() {
             @Override
             public void sendData(Object steps) {
                 WritableMap map = (WritableMap)steps;
-                callback.invoke(map);
+                promise.resolve(map);
             }
         });
     }

--- a/android/src/main/java/com/fitnesstracker/GoogleFit/HistoryCallback.java
+++ b/android/src/main/java/com/fitnesstracker/GoogleFit/HistoryCallback.java
@@ -1,5 +1,0 @@
-package com.fitnesstracker.GoogleFit;
-
-public interface HistoryCallback {
-    void sendData(Object data);
-}

--- a/android/src/main/java/com/fitnesstracker/RNFitnessTrackerModule.java
+++ b/android/src/main/java/com/fitnesstracker/RNFitnessTrackerModule.java
@@ -1,7 +1,7 @@
 package com.fitnesstracker;
 
 import android.app.Activity;
-import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -24,45 +24,45 @@ public class RNFitnessTrackerModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void authorize(Callback callback) {
+  public void authorize(Promise promise) {
     Activity activity = getCurrentActivity();
-    this.googleFitManager.authorize(callback, activity);
+    this.googleFitManager.authorize(promise, activity);
   }
 
 
   @ReactMethod
-  public void isTrackingAvailable(Callback callback) {
+  public void isTrackingAvailable(Promise promise) {
     Activity activity = getCurrentActivity();
-    this.googleFitManager.isTrackingAvailable(callback, activity);
+    this.googleFitManager.isTrackingAvailable(promise, activity);
   }
 
   @ReactMethod
-  public void getStepsToday(Callback callback) {
-    this.googleFitManager.getStepsToday(callback);
+  public void getStepsToday(Promise promise) {
+    this.googleFitManager.getStepsToday(promise);
   }
 
   @ReactMethod
-  public void getStepsWeekTotal(Callback callback) {
-    this.googleFitManager.getStepsWeekTotal(callback);
+  public void getStepsWeekTotal(Promise promise) {
+    this.googleFitManager.getStepsWeekTotal(promise);
   }
 
   @ReactMethod
-  public void getStepsDaily(Callback callback) {
-    this.googleFitManager.getStepsDaily(callback);
+  public void getStepsDaily(Promise promise) {
+    this.googleFitManager.getStepsDaily(promise);
   }
 
   @ReactMethod
-  public void getDistanceToday(Callback callback) {
-    this.googleFitManager.getDistanceToday(callback);
+  public void getDistanceToday(Promise promise) {
+    this.googleFitManager.getDistanceToday(promise);
   }
 
   @ReactMethod
-  public void getDistanceWeekTotal(Callback callback) {
-    this.googleFitManager.getDistanceWeekTotal(callback);
+  public void getDistanceWeekTotal(Promise promise) {
+    this.googleFitManager.getDistanceWeekTotal(promise);
   }
 
   @ReactMethod
-  public void getDistanceDaily(Callback callback) {
-    this.googleFitManager.getDistanceDaily(callback);
+  public void getDistanceDaily(Promise promise) {
+    this.googleFitManager.getDistanceDaily(promise);
   }
 }

--- a/ios/RNFitnessTracker.m
+++ b/ios/RNFitnessTracker.m
@@ -22,12 +22,14 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(isAuthorizedToUseCoreMotion:(RCTPromiseResolveBlock) resolve) {
+RCT_EXPORT_METHOD(isAuthorizedToUseCoreMotion:(RCTPromiseResolveBlock) resolve :
+                  (RCTPromiseRejectBlock) reject) {
     NSString *status = [self isCoreMotionAuthorized];
     resolve(@[status]);
 }
 
-RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve) {
+RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve :
+                  (RCTPromiseRejectBlock) reject) {
     BOOL isStepCountingAvailable = [CMPedometer isStepCountingAvailable];
     BOOL isDistanceAvailable = [CMPedometer isDistanceAvailable];
     BOOL isFloorCountingAvailable = [CMPedometer isFloorCountingAvailable];
@@ -35,7 +37,8 @@ RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve) {
     resolve(@[isStepCountingAvailable ? @true : @false, isDistanceAvailable ? @true : @false, isFloorCountingAvailable? @true : @false]);
 }
 
-RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve) {
+RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve :
+                  (RCTPromiseRejectBlock) reject) {
     BOOL isStepTrackingAvailable = [CMPedometer isStepCountingAvailable];
     if (isStepTrackingAvailable == YES) {
         resolve(@[@true]);
@@ -45,7 +48,8 @@ RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve) {
 }
 
 
-RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve) {
+RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve :
+                  (RCTPromiseRejectBlock) reject) {
     BOOL isDistanceTrackingAvailable = [CMPedometer isDistanceAvailable];
     if (isDistanceTrackingAvailable == YES) {
         resolve(@[@true]);
@@ -54,7 +58,8 @@ RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve) 
     }
 }
 
-RCT_EXPORT_METHOD(isFloorCountingSupported:(RCTPromiseResolveBlock) resolve) {
+RCT_EXPORT_METHOD(isFloorCountingSupported:(RCTPromiseResolveBlock) resolve :
+                  (RCTPromiseRejectBlock) reject) {
     BOOL isFloorCountingAvailable = [CMPedometer isFloorCountingAvailable];
     if (isFloorCountingAvailable == YES) {
         resolve(@[@true]);

--- a/ios/RNFitnessTracker.m
+++ b/ios/RNFitnessTracker.m
@@ -22,34 +22,44 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(isAuthorizedToUseCoreMotion:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(isAuthorizedToUseCoreMotion:(RCTPromiseResolveBlock) resolve {
     NSString *status = [self isCoreMotionAuthorized];
-    callback(@[status]);
+    resolve(@[status]);
 }
 
-RCT_EXPORT_METHOD(isTrackingSupported:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve {
     BOOL isStepCountingAvailable = [CMPedometer isStepCountingAvailable];
     BOOL isDistanceAvailable = [CMPedometer isDistanceAvailable];
     BOOL isFloorCountingAvailable = [CMPedometer isFloorCountingAvailable];
     
-    callback(@[isStepCountingAvailable ? @true : @false, isDistanceAvailable ? @true : @false, isFloorCountingAvailable? @true : @false]);
+    resolve(@[isStepCountingAvailable ? @true : @false, isDistanceAvailable ? @true : @false, isFloorCountingAvailable? @true : @false]);
 }
 
-RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTResponseSenderBlock)callback) {
-    BOOL isDistanceTrackingAvailable = [CMPedometer isDistanceAvailable];
-    if (isDistanceTrackingAvailable == YES) {
-        callback(@[@true]);
+RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve {
+    BOOL isStepTrackingAvailable = [CMPedometer isStepCountingAvailable];
+    if (isStepTrackingAvailable == YES) {
+        resolve(@[@true]);
     } else {
-        callback(@[@false]);
+        resolve(@[@false]);
     }
 }
 
-RCT_EXPORT_METHOD(isFloorCountingSupported:(RCTResponseSenderBlock)callback) {
+
+RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve {
+    BOOL isDistanceTrackingAvailable = [CMPedometer isDistanceAvailable];
+    if (isDistanceTrackingAvailable == YES) {
+        resolve(@[@true]);
+    } else {
+        resolve(@[@false]);
+    }
+}
+
+RCT_EXPORT_METHOD(isFloorCountingSupported:(RCTPromiseResolveBlock) resolve {
     BOOL isFloorCountingAvailable = [CMPedometer isFloorCountingAvailable];
     if (isFloorCountingAvailable == YES) {
-        callback(@[@true]);
+        resolve(@[@true]);
     } else {
-        callback(@[@false]);
+        resolve(@[@false]);
     }
 }
 

--- a/ios/RNFitnessTracker.m
+++ b/ios/RNFitnessTracker.m
@@ -25,7 +25,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(isAuthorizedToUseCoreMotion:(RCTPromiseResolveBlock) resolve :
                   (RCTPromiseRejectBlock) reject) {
     NSString *status = [self isCoreMotionAuthorized];
-    resolve(@[status]);
+    resolve(status);
 }
 
 RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve :
@@ -41,9 +41,9 @@ RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve :
                   (RCTPromiseRejectBlock) reject) {
     BOOL isStepTrackingAvailable = [CMPedometer isStepCountingAvailable];
     if (isStepTrackingAvailable == YES) {
-        resolve(@[@true]);
+        resolve(@true);
     } else {
-        resolve(@[@false]);
+        resolve(@false);
     }
 }
 
@@ -52,9 +52,9 @@ RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve :
                   (RCTPromiseRejectBlock) reject) {
     BOOL isDistanceTrackingAvailable = [CMPedometer isDistanceAvailable];
     if (isDistanceTrackingAvailable == YES) {
-        resolve(@[@true]);
+        resolve(@true);
     } else {
-        resolve(@[@false]);
+        resolve(@false);
     }
 }
 
@@ -62,9 +62,9 @@ RCT_EXPORT_METHOD(isFloorCountingSupported:(RCTPromiseResolveBlock) resolve :
                   (RCTPromiseRejectBlock) reject) {
     BOOL isFloorCountingAvailable = [CMPedometer isFloorCountingAvailable];
     if (isFloorCountingAvailable == YES) {
-        resolve(@[@true]);
+        resolve(@true);
     } else {
-        resolve(@[@false]);
+        resolve(@false);
     }
 }
 
@@ -78,14 +78,13 @@ RCT_EXPORT_METHOD(authorize:(RCTPromiseResolveBlock) resolve :
         NSDate *startDate = [self beginningOfDay:now];
         [_pedometer queryPedometerDataFromDate:(NSDate *)startDate toDate:(NSDate *)now withHandler:^(CMPedometerData * _Nullable pedometerData, NSError * _Nullable error) {
             if (error == nil) {
-                resolve(@[@true]);
+                resolve(@true);
             } else {
-                resolve(@[@false]);
+                resolve(@false);
             }
         }];
-    }
-    else {
-        resolve(@[@false]);
+    } else {
+        resolve(@false);
     }
 }
 
@@ -113,7 +112,7 @@ RCT_EXPORT_METHOD(authorize:(RCTPromiseResolveBlock) resolve :
             NSNumber *distance = pedometerData.distance;
             NSNumber *flights = pedometerData.floorsAscended;
             NSArray *data = (@[steps, distance, flights]);
-            resolve(@[data[dataType]]);
+            resolve(data[dataType]);
         } else {
             [self rejectError:error :reject];
         }
@@ -220,7 +219,7 @@ RCT_EXPORT_METHOD(getFloorsDaily:(RCTPromiseResolveBlock) resolve :(RCTPromiseRe
                 int newCount = count + 1;
                 [self getDailyWeekData:previousDay :newCount :dataType :data :resolve :reject];
             } else {
-                resolve(@[data]);
+                resolve(data);
             }
         } else {
             [self rejectError:error :reject];

--- a/ios/RNFitnessTracker.m
+++ b/ios/RNFitnessTracker.m
@@ -22,12 +22,12 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(isAuthorizedToUseCoreMotion:(RCTPromiseResolveBlock) resolve {
+RCT_EXPORT_METHOD(isAuthorizedToUseCoreMotion:(RCTPromiseResolveBlock) resolve) {
     NSString *status = [self isCoreMotionAuthorized];
     resolve(@[status]);
 }
 
-RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve {
+RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve) {
     BOOL isStepCountingAvailable = [CMPedometer isStepCountingAvailable];
     BOOL isDistanceAvailable = [CMPedometer isDistanceAvailable];
     BOOL isFloorCountingAvailable = [CMPedometer isFloorCountingAvailable];
@@ -35,7 +35,7 @@ RCT_EXPORT_METHOD(isTrackingSupported:(RCTPromiseResolveBlock) resolve {
     resolve(@[isStepCountingAvailable ? @true : @false, isDistanceAvailable ? @true : @false, isFloorCountingAvailable? @true : @false]);
 }
 
-RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve {
+RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve) {
     BOOL isStepTrackingAvailable = [CMPedometer isStepCountingAvailable];
     if (isStepTrackingAvailable == YES) {
         resolve(@[@true]);
@@ -45,7 +45,7 @@ RCT_EXPORT_METHOD(isStepTrackingSupported:(RCTPromiseResolveBlock) resolve {
 }
 
 
-RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve {
+RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve) {
     BOOL isDistanceTrackingAvailable = [CMPedometer isDistanceAvailable];
     if (isDistanceTrackingAvailable == YES) {
         resolve(@[@true]);
@@ -54,7 +54,7 @@ RCT_EXPORT_METHOD(isDistanceTrackingSupported:(RCTPromiseResolveBlock) resolve {
     }
 }
 
-RCT_EXPORT_METHOD(isFloorCountingSupported:(RCTPromiseResolveBlock) resolve {
+RCT_EXPORT_METHOD(isFloorCountingSupported:(RCTPromiseResolveBlock) resolve) {
     BOOL isFloorCountingAvailable = [CMPedometer isFloorCountingAvailable];
     if (isFloorCountingAvailable == YES) {
         resolve(@[@true]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.3-alpha.3",
+  "version": "0.1.3-alpha.4",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.2",
+  "version": "0.1.3-alpha.0",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.3-alpha.6",
+  "version": "0.1.3",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.3-alpha.4",
+  "version": "0.1.3-alpha.5",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.3-alpha.0",
+  "version": "0.1.3-alpha.1",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.3-alpha.1",
+  "version": "0.1.3-alpha.2",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.3-alpha.5",
+  "version": "0.1.3-alpha.6",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.1.3-alpha.2",
+  "version": "0.1.3-alpha.3",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -31,8 +31,15 @@ const floors = {
   },
 };
 
+const stepsWeekTotal = 204251;
+const distanceWeekTotal = 11600.88;
+const floorsWeekTotal = 21;
+
 export const mockData = {
   distance,
   floors,
   steps,
+  stepsWeekTotal,
+  distanceWeekTotal,
+  floorsWeekTotal,
 };


### PR DESCRIPTION
- Use promises instead of callbacks in native bridge.
- Reject promises on errors.
- Code formatting.
- Return mock data on iOS simulator on all getSteps, getDistance and getFloors calls.
- Other small improvements