### PR TITLE
Added ability to fetch daily week data and week total from HealthKit

### DIFF
--- a/api.md
+++ b/api.md
@@ -229,6 +229,7 @@ on `iOS simulator` returns mock data
     * [~getAbsoluteTotalForToday(key, unit)](#module_RNHealthTracker..getAbsoluteTotalForToday) ⇒ <code>Promise.&lt;number&gt;</code>
     * [~getStatisticTotalForToday(key, unit)](#module_RNHealthTracker..getStatisticTotalForToday) ⇒ <code>Promise.&lt;number&gt;</code>
     * [~recordWorkout(object)](#module_RNHealthTracker..recordWorkout) ⇒ <code>Promise.&lt;boolean&gt;</code>
+    * [~getAuthStatusForType(object)](#module_RNHealthTracker..getAuthStatusForType) ⇒ <code>Promise.&lt;number&gt;</code>
 
 
 * * *
@@ -330,6 +331,25 @@ Gets statistic total for given health data type and unit for current day, same n
 Records given workout data to Health API
 
 **Kind**: inner method of [<code>RNHealthTracker</code>](#module_RNHealthTracker)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| object | <code>object</code> |  |
+| object.startDate | <code>Date</code> \| <code>number</code> |  |
+| object.endDate | <code>Date</code> \| <code>number</code> |  |
+| object.energyBurned | <code>Number</code> | number of calories in kcal |
+| object.metadata | <code>object</code> |  |
+
+
+* * *
+
+<a name="module_RNHealthTracker..getAuthStatusForType"></a>
+
+### RNHealthTracker~getAuthStatusForType(object) ⇒ <code>Promise.&lt;number&gt;</code>
+Returns auth status for data type in Health API
+
+**Kind**: inner method of [<code>RNHealthTracker</code>](#module_RNHealthTracker)  
+**Returns**: <code>Promise.&lt;number&gt;</code> - 0 - notDetermined, 1 - sharingDenied, 2 - sharingAuthorized  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/ios/RNFitnessUtils.m
+++ b/ios/RNFitnessUtils.m
@@ -15,12 +15,11 @@
 }
 
 +(NSDate *)endOfDay:(NSDate *)date {
-    NSDate *nextDay = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitDay value:1 toDate:date options:0];
     NSCalendar *cal = [NSCalendar currentCalendar];
-    NSDateComponents *components = [cal components:( NSCalendarUnitDay| NSCalendarUnitMonth | NSCalendarUnitYear | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond ) fromDate:nextDay];
-    [components setHour:0];
-    [components setMinute:0];
-    [components setSecond:0];
+    NSDateComponents *components = [cal components:( NSCalendarUnitDay| NSCalendarUnitMonth | NSCalendarUnitYear | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond ) fromDate:date];
+    [components setHour:23];
+    [components setMinute:59];
+    [components setSecond:59];
     [components setMonth: components.month];
     [components setDay: components.day];
     [components setYear: components.year];

--- a/ios/RNHealthTracker.m
+++ b/ios/RNHealthTracker.m
@@ -286,4 +286,17 @@ RCT_EXPORT_METHOD(recordWorkout
 }
 
 
+RCT_EXPORT_METHOD(getAuthorizationStatusForType
+                  :(NSString*) dataTypeIdentifier
+                  :(RCTPromiseResolveBlock) resolve
+                  :(RCTPromiseRejectBlock) reject) {
+    
+    HKObjectType *type = [HKObjectType quantityTypeForIdentifier:[NSString stringWithFormat:@"HKQuantityTypeIdentifier%@", dataTypeIdentifier]];
+    
+    NSInteger status = [_healthStore authorizationStatusForType:type];
+    resolve(@(status));
+    
+}
+
+
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@kilohealth/rn-fitness-tracker",
-  "version": "0.2.4",
+  "name": "@kilohealth/rn-tracker",
+  "version": "0.2.5",
   "description": "Fitness tracker module",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/src/healthTracker.ts
+++ b/src/healthTracker.ts
@@ -175,7 +175,7 @@ const recordWorkout = async <DataKey extends keyof typeof WorkoutTypes>({
  * @param object.endDate {Date | number}
  * @param object.energyBurned {Number} number of calories in kcal
  * @param object.metadata {object}
- * @return {Promise<boolean>}
+ * @return {Promise<number>} 0 - notDetermined, 1 - sharingDenied, 2 - sharingAuthorized
  */
 const getAuthStatusForType = async <DataKey extends keyof typeof WorkoutTypes>(
   key: DataKey,

--- a/src/healthTracker.ts
+++ b/src/healthTracker.ts
@@ -136,6 +136,50 @@ const getStatisticTotalForToday = async <
 };
 
 /**
+ * Gets statistic total for given health data type and unit for current week, same number as in health app
+ * @param key {HealthDataType} e.g. `HealthDataTypes.Fiber`
+ * @param unit {UnitType} e.g. `UnitTypes.grams`
+ * @return {Promise<number>}
+ */
+const getStatisticTotalForWeek = async <
+  DataKey extends keyof typeof HealthDataTypes,
+  UnitKey extends keyof typeof UnitTypes
+>({
+  key,
+  unit,
+}: {
+  key: DataKey;
+  unit: UnitKey;
+}): Promise<number> => {
+  if (isIOS) {
+    const total = await RNHealthTracker.getStatisticTotalForWeek(key, unit);
+    return Number(total);
+  }
+};
+
+/**
+ * Gets statistic daily total for given health data type and unit for current week, same number as in health app
+ * @param key {HealthDataType} e.g. `HealthDataTypes.Fiber`
+ * @param unit {UnitType} e.g. `UnitTypes.grams`
+ * @return {Promise<number>}
+ */
+const getStatisticWeekDaily = async <
+  DataKey extends keyof typeof HealthDataTypes,
+  UnitKey extends keyof typeof UnitTypes
+>({
+  key,
+  unit,
+}: {
+  key: DataKey;
+  unit: UnitKey;
+}): Promise<{}> => {
+  if (isIOS) {
+    const total = await RNHealthTracker.getStatisticWeekDaily(key, unit);
+    return total;
+  }
+};
+
+/**
  * Records given workout data to Health API
  * @param object {object}
  * @param object.startDate {Date | number}
@@ -189,6 +233,8 @@ export const HealthTrackerAPI = {
   getAuthStatusForType,
   getAbsoluteTotalForToday,
   getStatisticTotalForToday,
+  getStatisticTotalForWeek,
+  getStatisticWeekDaily,
   isTrackingSupportedIOS,
   recordWorkout,
   setupTracking,

--- a/src/healthTracker.ts
+++ b/src/healthTracker.ts
@@ -168,7 +168,25 @@ const recordWorkout = async <DataKey extends keyof typeof WorkoutTypes>({
   }
 };
 
+/**
+ * Returns auth status for data type in Health API
+ * @param object {object}
+ * @param object.startDate {Date | number}
+ * @param object.endDate {Date | number}
+ * @param object.energyBurned {Number} number of calories in kcal
+ * @param object.metadata {object}
+ * @return {Promise<boolean>}
+ */
+const getAuthStatusForType = async <DataKey extends keyof typeof WorkoutTypes>(
+  key: DataKey,
+): Promise<boolean> => {
+  if (isIOS) {
+    return await RNHealthTracker.getAuthorizationStatusForType(key);
+  }
+};
+
 export const HealthTrackerAPI = {
+  getAuthStatusForType,
   getAbsoluteTotalForToday,
   getStatisticTotalForToday,
   isTrackingSupportedIOS,

--- a/src/utils/dataTypes.ts
+++ b/src/utils/dataTypes.ts
@@ -48,6 +48,44 @@ export const HealthDataTypes = {
   BodyFatPercentage: 'BodyFatPercentage',
   WaistCircumference: 'WaistCircumference',
 
+  // Activity
+  StepCount: 'StepCount',
+  DistanceWalkingRunning: 'DistanceWalkingRunning',
+  DistanceCycling: 'DistanceCycling',
+  PushCount: 'PushCount',
+  DistanceWheelchair: 'DistanceWheelchair',
+  SwimmingStrokeCount: 'SwimmingStrokeCount',
+  DistanceDownhillSnowSports: 'DistanceDownhillSnowSports',
+  BasalEnergyBurned: 'BasalEnergyBurned',
+  FlightsClimbed: 'FlightsClimbed',
+  NikeFuelPoints: 'NikeFuel',
+  ExerciseTime: 'AppleExerciseTime',
+  StandTime: 'AppleStandTime',
+
+  // Lab and Test Results
+  BloodAlcoholContent: 'BloodAlcoholContent',
+  BloodGlucose: 'BloodGlucose',
+  ElectrodermalActivity: 'ElectrodermalActivity',
+  ForcedExpiratoryVolume1: 'ForcedExpiratoryVolume1',
+  ForcedVitalCapacity: 'ForcedVitalCapacity',
+  InhalerUsage: 'InhalerUsage',
+  InsulinDelivery: 'InsulinDelivery',
+  NumberOfTimesFallen: 'NumberOfTimesFallen',
+  PeakExpiratoryFlowRate: 'PeakExpiratoryFlowRate',
+  PeripheralPerfusionIndex: 'PeripheralPerfusionIndex',
+
+  // Vital signs
+  HeartRate: 'HeartRate',
+  RestingHeartRate: 'RestingHeartRate',
+  HeartRateVariabilitySDNN: 'HeartRateVariabilitySDNN',
+  WalkingHeartRateAverage: 'WalkingHeartRateAverage',
+  OxygenSaturation: 'OxygenSaturation',
+  BodyTemperature: 'BodyTemperature',
+  BloodPressureSystolic: 'BloodPressureSystolic',
+  BloodPressureDiastolic: 'BloodPressureDiastolic',
+  RespiratoryRate: 'RespiratoryRate',
+  VO2Max: 'VO2Max',
+
   // Workout
   Workout: 'Workout',
 };


### PR DESCRIPTION
**Added**

- Data types for Activity, Lab&Test results, Vital Signs
- Method to check auth status for datatype @ healthKit
- Methods to get statistic total for week and daily data for week
- Method `getAuthStatusForType` to get authorization status for HealthKit data type

**Fixed**
- getEndOfDay to return today 23:59:59 not 00:00:00 of next day