### PR TITLE
v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilohealth/rn-fitness-tracker",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Fitness & Health tracking package for React Native for Android & iOS",
   "homepage": "https://github.com/doville/rn-fitness-tracker",
   "repository": "https://github.com/doville/rn-fitness-tracker",

--- a/src/api/fitness.ts
+++ b/src/api/fitness.ts
@@ -88,6 +88,8 @@ const setupTracking = async (
     if (!isMotionAuthNeeded || motionAuthorized === RESULTS.GRANTED) {
       const authorized: boolean = await RNFitnessTracker.authorize();
       return { authorized, shouldOpenAppSettings: false };
+    } else if (motionAuthorized === RESULTS.DENIED) {
+      return { authorized: false, shouldOpenAppSettings: false };
     } else {
       return { authorized: false, shouldOpenAppSettings: true };
     }


### PR DESCRIPTION
**Fixed:**

- Handle Android X user rejection and blocking for motion tracking permission - on `setupTracking()` return `shouldOpenAppSettings` - `false` when user denies permission, `true` - when user blocks permission (f53b6b4)